### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ on:
 
 jobs:
   ios-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.3.0.app
     - name: Build
       run: xcodebuild build -scheme AppScreenshotKit-Package -destination generic/platform=iOS
     - name: Run tests
-      run: echo "testing"
+      run: echo "testing" # Replace this command once unit test is ready.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  ios-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: xcodebuild build -scheme AppScreenshotKit-Package -destination generic/platform=iOS
+    - name: Run tests
+      run: echo "testing"

--- a/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
+++ b/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
@@ -11,10 +11,30 @@ import PackagePlugin
 @main
 struct RegisterBezelsCommand: BuildToolPlugin {
     func createBuildCommands(context: PackagePlugin.PluginContext, target: any PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
-
         let cacheDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
         let bezelsDirectoryURL = cacheDirectoryURL.appending(path: "com.shitamori1272.AppScreenshotKit/AppleDesignResource")
         let outputDirectoryURL = context.pluginWorkDirectoryURL.appending(path: "AppleDesignResource")
+
+        guard FileManager.default.fileExists(atPath: bezelsDirectoryURL.path) else {
+            Diagnostics.warning("No bezels found in \(bezelsDirectoryURL.path). Please run the command to download bezels first.\n \"swift run AppScreenshotKitCLI download-bezel-image\"")
+
+            return [
+                .buildCommand(
+                    displayName: "Register Dummy Bezel image file",
+                    executable: URL(fileURLWithPath: "/usr/bin/touch"),
+                    arguments: [
+                        outputDirectoryURL.appending(path: "dummy.txt").path()
+                    ],
+                    environment: [:],
+                    inputFiles: [
+                        cacheDirectoryURL
+                    ],
+                    outputFiles: [
+                        outputDirectoryURL
+                    ]
+                )
+            ]
+        }
 
         return [
             .buildCommand(

--- a/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
+++ b/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
@@ -18,6 +18,8 @@ struct RegisterBezelsCommand: BuildToolPlugin {
         guard FileManager.default.fileExists(atPath: bezelsDirectoryURL.path) else {
             Diagnostics.warning("No bezels found in \(bezelsDirectoryURL.path). Please run the command to download bezels first.\n \"swift run AppScreenshotKitCLI download-bezel-image\"")
 
+            try FileManager.default.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
+
             return [
                 .buildCommand(
                     displayName: "Register Dummy Bezel image file",


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the build and testing of a Swift project. The workflow is triggered on pushes to the `main` branch and on all pull requests.

### CI Workflow Addition:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R20): Introduced a new CI workflow named `CI` that runs on `macos-latest`. It checks out the code, builds the project using `xcodebuild` with the `AppScreenshotKit-Package` scheme for a generic iOS platform, and includes a placeholder step for running tests.