### PR TITLE
Fix BezelImageLoader to handle paths with spaces and non-ASCII characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ fastlane/test_output
 AppleDesignResource
 Results
 .vscode
+.claude/

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,10 @@ let package = Package(
             capability: .buildTool()
         ),
         .testTarget(
+            name: "AppScreenshotCoreTests",
+            dependencies: ["AppScreenshotCore"]
+        ),
+        .testTarget(
             name: "AppScreenshotKitTests",
             dependencies: ["AppScreenshotKit"]
         ),

--- a/Sources/AppScreenshotCore/Utils/BezelImageLoader.swift
+++ b/Sources/AppScreenshotCore/Utils/BezelImageLoader.swift
@@ -11,18 +11,24 @@ struct BezelImageLoader {
 
     func imageData(_ device: AppScreenshotDevice, resourceBaseURL: URL) throws -> Data {
         let imageFileNameCandidates = imageFileNameCandidates(device)
-        guard let filePaths = FileManager.default.subpaths(atPath: resourceBaseURL.path()),
-            let imageFilePath = filePaths.first(where: { path in
-                imageFileNameCandidates.contains(where: { name in path.hasSuffix(name) })
+        let fileURLs =
+            FileManager.default.enumerator(
+                at: resourceBaseURL,
+                includingPropertiesForKeys: nil
+            )?
+            .allObjects as? [URL] ?? []
+        guard
+            let imageURL = fileURLs.first(where: { url in
+                imageFileNameCandidates.contains(url.lastPathComponent)
             })
         else {
             throw AppScreenshotKitError(
                 message:
-                    "No image file found: \(imageFileNameCandidates[0]) in \(resourceBaseURL.path())"
+                    "No image file found: \(imageFileNameCandidates[0]) in \(resourceBaseURL.path(percentEncoded: false))"
             )
         }
 
-        return try Data(contentsOf: resourceBaseURL.appendingPathComponent(imageFilePath))
+        return try Data(contentsOf: imageURL)
     }
 
     private func imageFileNameCandidates(_ device: AppScreenshotDevice) -> [String] {

--- a/Tests/AppScreenshotCoreTests/BezelImageLoaderTests.swift
+++ b/Tests/AppScreenshotCoreTests/BezelImageLoaderTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+
+@testable import AppScreenshotCore
+
+@Suite
+final class BezelImageLoaderTests {
+
+    private let tempRootURL: URL
+
+    init() throws {
+        tempRootURL = FileManager.default.temporaryDirectory.appending(
+            path: "BezelImageLoaderTests-\(UUID().uuidString)"
+        )
+        try FileManager.default.createDirectory(
+            at: tempRootURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempRootURL)
+    }
+
+    // MARK: - Helpers
+
+    private static let device = AppScreenshotDevice(
+        orientation: .portrait,
+        color: .black,
+        model: .iPhone16ProMax
+    )
+
+    /// Expected file name for `Self.device` per the loader's naming rule.
+    private static let expectedFileName = "iPhone 16 Pro Max - Black - Portrait.png"
+
+    /// Bezel images are downloaded into a nested directory tree such as
+    /// `<base>/Bezels/Apple-Sketch-Library-Product-Bezels/<filename>.png`.
+    /// Recreate that nesting to make sure the loader walks subdirectories.
+    @discardableResult
+    private func writeBezelFile(
+        under baseDirectory: URL,
+        fileName: String = BezelImageLoaderTests.expectedFileName,
+        contents: Data = Data([0x89, 0x50, 0x4E, 0x47])  // "\x89PNG"
+    ) throws -> URL {
+        let nestedDirectory = baseDirectory
+            .appending(path: "Bezels")
+            .appending(path: "Apple-Sketch-Library-Product-Bezels")
+        try FileManager.default.createDirectory(
+            at: nestedDirectory,
+            withIntermediateDirectories: true
+        )
+        let fileURL = nestedDirectory.appending(path: fileName)
+        try contents.write(to: fileURL)
+        return fileURL
+    }
+
+    // MARK: - Regression: existing behavior still works
+
+    @Test
+    func returnsBezelData_forAsciiPath() throws {
+        let baseDirectory = tempRootURL.appending(path: "AppleDesignResource")
+        let expectedFileURL = try writeBezelFile(under: baseDirectory)
+        let expectedData = try Data(contentsOf: expectedFileURL)
+
+        let data = try BezelImageLoader().imageData(
+            Self.device,
+            resourceBaseURL: baseDirectory
+        )
+
+        #expect(data == expectedData)
+    }
+
+    @Test
+    func throws_whenMatchingFileMissing() throws {
+        let baseDirectory = tempRootURL.appending(path: "AppleDesignResource")
+        // Place an unrelated file so the directory is non-empty.
+        try writeBezelFile(
+            under: baseDirectory,
+            fileName: "Unrelated - White - Landscape.png"
+        )
+
+        #expect(throws: AppScreenshotKitError.self) {
+            try BezelImageLoader().imageData(
+                Self.device,
+                resourceBaseURL: baseDirectory
+            )
+        }
+    }
+
+    @Test
+    func walksDeepDirectoryStructure() throws {
+        let baseDirectory = tempRootURL.appending(path: "AppleDesignResource")
+        let deeplyNested = baseDirectory
+            .appending(path: "level1")
+            .appending(path: "level2")
+            .appending(path: "level3")
+        try FileManager.default.createDirectory(
+            at: deeplyNested,
+            withIntermediateDirectories: true
+        )
+        let payload = Data("deep".utf8)
+        try payload.write(to: deeplyNested.appending(path: Self.expectedFileName))
+
+        let data = try BezelImageLoader().imageData(
+            Self.device,
+            resourceBaseURL: baseDirectory
+        )
+
+        #expect(data == payload)
+    }
+
+    // MARK: - Bug fix: paths that get percent-encoded by URL.path()
+
+    /// Before the fix, `subpaths(atPath: url.path())` was passed a percent-encoded
+    /// path (e.g. `/tmp/.../with%20space/...`). `FileManager` could not open that
+    /// directory and returned `nil`, so the loader threw "No image file found"
+    /// even though the file existed. This test fails on the old implementation.
+    @Test
+    func resolvesBezel_whenBaseDirectoryContainsSpaces() throws {
+        let baseDirectory = tempRootURL
+            .appending(path: "with space")
+            .appending(path: "AppleDesignResource")
+        let expectedFileURL = try writeBezelFile(under: baseDirectory)
+        let expectedData = try Data(contentsOf: expectedFileURL)
+
+        // Sanity-check that this test is actually exercising the bug it claims to:
+        // URL.path() must percent-encode the space, and subpaths(atPath:) must
+        // return nil for that encoded path. If either invariant ever stops
+        // holding, this test no longer guards the regression.
+        let encodedPath = baseDirectory.path()
+        try #require(encodedPath.contains("%20"))
+        try #require(FileManager.default.subpaths(atPath: encodedPath) == nil)
+
+        let data = try BezelImageLoader().imageData(
+            Self.device,
+            resourceBaseURL: baseDirectory
+        )
+
+        #expect(data == expectedData)
+    }
+
+    @Test
+    func resolvesBezel_whenBaseDirectoryContainsNonAsciiCharacters() throws {
+        let baseDirectory = tempRootURL
+            .appending(path: "テスト")
+            .appending(path: "AppleDesignResource")
+        let expectedFileURL = try writeBezelFile(under: baseDirectory)
+        let expectedData = try Data(contentsOf: expectedFileURL)
+
+        let encodedPath = baseDirectory.path()
+        try #require(encodedPath.contains("%"))
+        try #require(FileManager.default.subpaths(atPath: encodedPath) == nil)
+
+        let data = try BezelImageLoader().imageData(
+            Self.device,
+            resourceBaseURL: baseDirectory
+        )
+
+        #expect(data == expectedData)
+    }
+}


### PR DESCRIPTION
## Summary

`BezelImageLoader.imageData(_:resourceBaseURL:)` failed to find bezel images
whenever the absolute path of `resourceBaseURL` contained a space or a
non-ASCII character (e.g. a user account named `My User` or `下森`).

## Root cause

The loader called:

```swift
FileManager.default.subpaths(atPath: resourceBaseURL.path())
```

`URL.path()` percent-encodes spaces and non-ASCII characters, but
`FileManager.subpaths(atPath:)` treats the input as a literal filesystem
path and does not decode it. The result is `nil` for any path that gets
encoded, and the loader throws "No image file found" even though the
bezel exists on disk.

I verified this empirically: `subpaths(atPath: \"/tmp/with%20space\")` returns
`nil`, while `subpaths(atPath: \"/tmp/with space\")` returns the expected
entries.

## Fix

Switch to URL-based directory enumeration with
`FileManager.enumerator(at:includingPropertiesForKeys:)`. This avoids
the encoding round-trip entirely and produces `[URL]` directly. File
matching is done with `lastPathComponent` against the candidate filenames.

## Tests

Added a new `AppScreenshotCoreTests` test target (Swift Testing) covering:

**Regression** (existing behavior preserved):
- `returnsBezelData_forAsciiPath` — basic ASCII path resolution.
- `throws_whenMatchingFileMissing` — error path when the file is absent.
- `walksDeepDirectoryStructure` — recursive descent into nested directories.

**Bug fix** (failed on the old implementation):
- `resolvesBezel_whenBaseDirectoryContainsSpaces`
- `resolvesBezel_whenBaseDirectoryContainsNonAsciiCharacters`

The two bug-fix tests include `#require` preconditions that explicitly
assert `URL.path()` percent-encodes the directory and that
`subpaths(atPath:)` returns `nil` for that encoded path, so the test
documents the exact mechanism it is guarding against.

Verified manually: with the old implementation, the two bug-fix tests
fail; with the new implementation, all five pass.

## Origin

Inspired by part of the closed PR #22 (the BezelImageLoader portion).
This PR cherry-picks just that focused fix and adds dedicated tests.

## Test plan

- [x] \`swift test --filter BezelImageLoaderTests\` passes (5 tests, 0 failures).
- [x] Confirmed the two bug-fix tests fail when the change to
  \`BezelImageLoader.swift\` is reverted.