### PR TITLE
Fix RegisterBezelsCommand to handle special-character paths and avoid double-nest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,9 @@ let package = Package(
             name: "AppScreenshotKitCLITests",
             dependencies: ["AppScreenshotKitCLI"]
         ),
+        .testTarget(
+            name: "RegisterBezelsCommandTests"
+        ),
         .target(
             name: "AppScreenshotMacro",
             dependencies: [

--- a/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
+++ b/Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift
@@ -32,7 +32,7 @@ struct RegisterBezelsCommand: BuildToolPlugin {
                     displayName: "Register Dummy Bezel image file",
                     executable: URL(fileURLWithPath: "/usr/bin/touch"),
                     arguments: [
-                        outputDirectoryURL.appending(path: "dummy.txt").path()
+                        outputDirectoryURL.appending(path: "dummy.txt").path(percentEncoded: false)
                     ],
                     environment: [:],
                     inputFiles: [
@@ -50,9 +50,13 @@ struct RegisterBezelsCommand: BuildToolPlugin {
                 displayName: "Register Bezel images",
                 executable: URL(fileURLWithPath: "/bin/cp"),
                 arguments: [
+                    // Trailing `/.` copies the *contents* of the source directory
+                    // into the destination. `cp -R src dst` would copy the source
+                    // *directory itself* into `dst` whenever `dst` already exists,
+                    // producing `dst/<srcname>/...` on a second invocation.
                     "-R",
-                    bezelsDirectoryURL.path(),
-                    outputDirectoryURL.path(),
+                    bezelsDirectoryURL.path(percentEncoded: false) + "/.",
+                    outputDirectoryURL.path(percentEncoded: false),
                 ],
                 environment: [:],
                 inputFiles: [

--- a/Tests/RegisterBezelsCommandTests/CopyBezelsTests.swift
+++ b/Tests/RegisterBezelsCommandTests/CopyBezelsTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+/// Behavioral tests for the `cp` invocation produced by `Plugins/RegisterBezelsCommand`.
+///
+/// SwiftPM build-tool plugin targets cannot be imported into a test target, so
+/// these tests exercise the same `cp` invocation the plugin emits by running
+/// `/bin/cp` via `Process` with arguments constructed identically to the plugin.
+///
+/// If the argument format in `Plugins/RegisterBezelsCommand/RegisterBezelsCommand.swift`
+/// changes, mirror the change in `pluginCpArguments(src:dst:)` below.
+@Suite
+final class CopyBezelsTests {
+
+    private let tempRootURL: URL
+
+    init() throws {
+        tempRootURL = FileManager.default.temporaryDirectory.appending(
+            path: "RegisterBezelsCommandTests-\(UUID().uuidString)"
+        )
+        try FileManager.default.createDirectory(at: tempRootURL, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempRootURL)
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors the argument list emitted by `RegisterBezelsCommand`.
+    private func pluginCpArguments(src: URL, dst: URL) -> [String] {
+        [
+            "-R",
+            src.path(percentEncoded: false) + "/.",
+            dst.path(percentEncoded: false),
+        ]
+    }
+
+    @discardableResult
+    private func runCp(_ arguments: [String]) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/cp")
+        process.arguments = arguments
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    /// Build a minimal bezel-like source tree:
+    /// `<dir>/Bezels/Apple-Sketch-Library-Product-Bezels/<filename>` with given contents.
+    @discardableResult
+    private func makeBezelSource(
+        at sourceURL: URL,
+        fileName: String = "iPhone 16 Pro Max - Black - Portrait.png",
+        contents: Data = Data("bezel-data".utf8)
+    ) throws -> URL {
+        let nestedDirectory = sourceURL
+            .appending(path: "Bezels")
+            .appending(path: "Apple-Sketch-Library-Product-Bezels")
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+        let fileURL = nestedDirectory.appending(path: fileName)
+        try contents.write(to: fileURL)
+        return fileURL
+    }
+
+    private func bezelDataInDestination(_ dst: URL, fileName: String) -> Data? {
+        try? Data(
+            contentsOf: dst
+                .appending(path: "Bezels")
+                .appending(path: "Apple-Sketch-Library-Product-Bezels")
+                .appending(path: fileName)
+        )
+    }
+
+    // MARK: - Regression: existing behavior preserved
+
+    @Test
+    func copiesContents_withAsciiPaths() throws {
+        let src = tempRootURL.appending(path: "src")
+        let dst = tempRootURL.appending(path: "dst")
+        let payload = Data("payload".utf8)
+        try makeBezelSource(at: src, contents: payload)
+
+        let status = try runCp(pluginCpArguments(src: src, dst: dst))
+        #expect(status == 0)
+        #expect(bezelDataInDestination(dst, fileName: "iPhone 16 Pro Max - Black - Portrait.png") == payload)
+    }
+
+    @Test
+    func idempotent_acrossMultipleInvocations() throws {
+        let src = tempRootURL.appending(path: "src")
+        let dst = tempRootURL.appending(path: "dst")
+        try makeBezelSource(at: src)
+
+        // Run twice. The destination already exists on the second pass, which is
+        // exactly the configuration that triggered the bug under the old args.
+        try runCp(pluginCpArguments(src: src, dst: dst))
+        try runCp(pluginCpArguments(src: src, dst: dst))
+
+        // The source's tree must not appear nested inside the destination.
+        let nested = dst
+            .appending(path: src.lastPathComponent)
+            .appending(path: "Bezels")
+        #expect(!FileManager.default.fileExists(atPath: nested.path(percentEncoded: false)))
+        #expect(bezelDataInDestination(dst, fileName: "iPhone 16 Pro Max - Black - Portrait.png") != nil)
+    }
+
+    @Test
+    func reflectsUpdatedSourceContents_onSecondInvocation() throws {
+        let src = tempRootURL.appending(path: "src")
+        let dst = tempRootURL.appending(path: "dst")
+        try makeBezelSource(at: src, contents: Data("v1".utf8))
+        try runCp(pluginCpArguments(src: src, dst: dst))
+
+        try makeBezelSource(at: src, contents: Data("v2".utf8))
+        try runCp(pluginCpArguments(src: src, dst: dst))
+
+        #expect(
+            bezelDataInDestination(dst, fileName: "iPhone 16 Pro Max - Black - Portrait.png")
+                == Data("v2".utf8)
+        )
+    }
+
+    // MARK: - Bug fix: double-nest no longer happens
+
+    /// Demonstrates the original bug to lock in the fix: the *old* argument
+    /// shape (`cp -R src dst`, no trailing `/.`) creates `dst/<srcname>/...`
+    /// the second time around. If this ever stops being true, the trailing
+    /// `/.` in `pluginCpArguments` is no longer guarding the regression and
+    /// the test design needs to be revisited.
+    @Test
+    func oldArguments_demonstratesDoubleNestBug() throws {
+        let src = tempRootURL.appending(path: "src")
+        let dst = tempRootURL.appending(path: "dst")
+        try makeBezelSource(at: src)
+
+        let oldArgs: [String] = [
+            "-R",
+            src.path(percentEncoded: false),
+            dst.path(percentEncoded: false),
+        ]
+        try runCp(oldArgs)
+        try runCp(oldArgs)
+
+        let doubleNestedFile = dst
+            .appending(path: src.lastPathComponent)
+            .appending(path: "Bezels")
+            .appending(path: "Apple-Sketch-Library-Product-Bezels")
+            .appending(path: "iPhone 16 Pro Max - Black - Portrait.png")
+        #expect(FileManager.default.fileExists(atPath: doubleNestedFile.path(percentEncoded: false)))
+    }
+
+    // MARK: - Bug fix: paths with spaces / non-ASCII are no longer percent-encoded
+
+    @Test
+    func copiesContents_whenSourceContainsSpaces() throws {
+        let parent = tempRootURL.appending(path: "with space")
+        let src = parent.appending(path: "src")
+        let dst = parent.appending(path: "dst")
+        let payload = Data("space-payload".utf8)
+        try makeBezelSource(at: src, contents: payload)
+
+        // Sanity check: the OLD code path passed `URL.path()`, which percent-encodes
+        // the space and yields a string `cp` cannot resolve.
+        try #require(src.path().contains("%20"))
+
+        let status = try runCp(pluginCpArguments(src: src, dst: dst))
+        #expect(status == 0)
+        #expect(bezelDataInDestination(dst, fileName: "iPhone 16 Pro Max - Black - Portrait.png") == payload)
+    }
+
+    @Test
+    func copiesContents_whenDestinationContainsNonAsciiCharacters() throws {
+        let parent = tempRootURL.appending(path: "テスト")
+        let src = parent.appending(path: "src")
+        let dst = parent.appending(path: "dst")
+        let payload = Data("non-ascii-payload".utf8)
+        try makeBezelSource(at: src, contents: payload)
+
+        try #require(dst.path().contains("%"))
+
+        let status = try runCp(pluginCpArguments(src: src, dst: dst))
+        #expect(status == 0)
+        #expect(bezelDataInDestination(dst, fileName: "iPhone 16 Pro Max - Black - Portrait.png") == payload)
+    }
+
+    /// Demonstrates that the *old* argument shape (`URL.path()`) fails when
+    /// the path contains characters that get percent-encoded. Locks in the
+    /// rationale for `path(percentEncoded: false)` in `pluginCpArguments`.
+    @Test
+    func oldArguments_demonstratesPercentEncodingBug() throws {
+        let parent = tempRootURL.appending(path: "with space")
+        let src = parent.appending(path: "src")
+        let dst = parent.appending(path: "dst")
+        try makeBezelSource(at: src)
+
+        let oldArgs: [String] = [
+            "-R",
+            src.path() + "/.",  // percent-encoded: cp cannot open this
+            dst.path(),
+        ]
+        let status = try runCp(oldArgs)
+        #expect(status != 0)
+    }
+}


### PR DESCRIPTION
## Summary

The bezel-registration build plugin had two latent bugs in its `cp` invocation that would surface in real user environments.

## Bugs

### 1. Paths get percent-encoded and `cp` fails

`URL.path()` percent-encodes spaces and non-ASCII characters. `/bin/cp` treats arguments as literal filesystem paths, so any user whose home directory contains a space (`/Users/My User/...`) or non-ASCII character would see the build fail with `cp: <encoded-path>: No such file or directory`.

### 2. `cp -R src dst` double-nests on re-invocation

`cp -R src dst` copies the *source directory itself* into `dst` whenever `dst` already exists. If the build command re-ran for any reason (e.g. a clean rebuild after the cache was populated, or SPM detecting an input change), the output would be nested as `outputDirectoryURL/AppleDesignResource/Bezels/...` instead of `outputDirectoryURL/Bezels/...`, breaking bezel lookup at runtime.

I considered the PR-22 approach (pre-clean the destination + `cp -R src/. dst`) but verified empirically that **`cp -R src/. dst` alone is sufficient and idempotent** whether `dst` exists or not. Skipping the pre-clean avoids forcing the build command to re-run on every build.

## Fix

- Use `URL.path(percentEncoded: false)` for every path passed to `/bin/cp` and `/usr/bin/touch`.
- Append `/.` to the source path so `cp -R` copies the *contents* of the source directory regardless of whether `dst` exists.

## Tests

Added a new `RegisterBezelsCommandTests` test target. Build-tool plugin targets cannot be imported into a test target, so the tests reproduce the plugin's `cp` invocation by constructing the same arguments and running `/bin/cp` via `Process`. A `pluginCpArguments(src:dst:)` helper mirrors the plugin's argument list one-to-one; if the plugin's arg shape ever changes, the helper must be updated to match (cross-referenced via comments in both files).

**Regression** (existing behavior preserved):
- `copiesContents_withAsciiPaths` — basic case still works.
- `idempotent_acrossMultipleInvocations` — running twice does not double-nest.
- `reflectsUpdatedSourceContents_onSecondInvocation` — second run picks up new content from source.

**Bug fix** (would fail under the old args):
- `copiesContents_whenSourceContainsSpaces`
- `copiesContents_whenDestinationContainsNonAsciiCharacters`

**Bug demonstration** (pinned negative tests that exercise the *old* argument shape):
- `oldArguments_demonstratesDoubleNestBug` — `cp -R src dst` on a pre-existing `dst` produces a double-nested layout. Documents why the trailing `/.` is required.
- `oldArguments_demonstratesPercentEncodingBug` — `URL.path()` produces a percent-encoded path that `cp` cannot resolve. Documents why `path(percentEncoded: false)` is required.

I also ran two mutation tests locally to verify the test design:
- Removing `/.` from `pluginCpArguments` made `idempotent_acrossMultipleInvocations` and `reflectsUpdatedSourceContents_onSecondInvocation` fail as expected.
- Reverting `path(percentEncoded: false)` to `path()` made the spaces / non-ASCII tests fail as expected.

## Origin

Inspired by part of the closed PR #22 (the `RegisterBezelsCommand` portion). This PR cherry-picks the focused fix, simplifies it (drops the unnecessary pre-clean), and adds dedicated tests.

## Test plan

- [x] \`swift test --filter CopyBezelsTests\` passes (7/7).
- [x] Mutation tests confirm each invariant is guarded by at least one failing test when the corresponding fix is reverted.
- [x] Existing test suites still pass except for the pre-existing \`AppScreenshotKitTestToolsTests\` failures, which depend on real bezel images being present in the local cache and are unrelated to this change.