### PR TITLE
Render SwiftUI Materials through host app

### DIFF
--- a/Demo/DemoApp.xcodeproj/project.pbxproj
+++ b/Demo/DemoApp.xcodeproj/project.pbxproj
@@ -1,0 +1,461 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7747C7646C100FF7FA2C55F9 /* DemoAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03DECCC43EE647A543BD618 /* DemoAppApp.swift */; };
+		8C3488F436DA46D3B0F66587 /* MaterialDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE2D93E545547E09DB3DF26 /* MaterialDemoView.swift */; };
+		B7577D0A27C371E0E3AC3BB6 /* AppScreenshotKit in Frameworks */ = {isa = PBXBuildFile; productRef = F7C3850B93A8BA0AF7FC42C9 /* AppScreenshotKit */; };
+		E19DB2EC663CDF122DF93097 /* AppScreenshotKitTestTools in Frameworks */ = {isa = PBXBuildFile; productRef = 624FD8E09263B91AAD38685C /* AppScreenshotKitTestTools */; };
+		EC5303E75A3E1D1BED05778B /* ScreenshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01BFB7AB99143EBAD0FC102 /* ScreenshotsTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1D82B40CD4FBA248FDB68749 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3ACCC0531C14DF86AB1980F5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD9365CEE296087B81D5EDE0;
+			remoteInfo = DemoApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		154FAE636D5E23DF886F3868 /* DemoApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		593C65694F8FC82BA65DDC86 /* DemoAppTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = DemoAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FD9816AECC244CDFCF7C07E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7FE2D93E545547E09DB3DF26 /* MaterialDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialDemoView.swift; sourceTree = "<group>"; };
+		E03DECCC43EE647A543BD618 /* DemoAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppApp.swift; sourceTree = "<group>"; };
+		F01BFB7AB99143EBAD0FC102 /* ScreenshotsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		631EEB8FD7848E1438134A16 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EDD6A0C2DAC6C9A9F1D629F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B7577D0A27C371E0E3AC3BB6 /* AppScreenshotKit in Frameworks */,
+				E19DB2EC663CDF122DF93097 /* AppScreenshotKitTestTools in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		440193E401A4E83EEA00B144 = {
+			isa = PBXGroup;
+				children = (
+					F1DF8958A1BCF35E04E58873 /* DemoApp */,
+					F6ABEB16F0AFF4E5F24B5294 /* DemoAppTests */,
+					D4CC74EBFCAF08A1E61D64BF /* Products */,
+				);
+				sourceTree = "<group>";
+			};
+		D4CC74EBFCAF08A1E61D64BF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				154FAE636D5E23DF886F3868 /* DemoApp.app */,
+				593C65694F8FC82BA65DDC86 /* DemoAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F1DF8958A1BCF35E04E58873 /* DemoApp */ = {
+			isa = PBXGroup;
+				children = (
+					E03DECCC43EE647A543BD618 /* DemoAppApp.swift */,
+					7FE2D93E545547E09DB3DF26 /* MaterialDemoView.swift */,
+					5FD9816AECC244CDFCF7C07E /* Info.plist */,
+				);
+			path = DemoApp;
+			sourceTree = "<group>";
+		};
+		F6ABEB16F0AFF4E5F24B5294 /* DemoAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				F01BFB7AB99143EBAD0FC102 /* ScreenshotsTests.swift */,
+			);
+			path = DemoAppTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		98E24D6FA44C1D3D84659D04 /* DemoAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F9A1D6DC5F0C8CC9CE81F4D0 /* Build configuration list for PBXNativeTarget "DemoAppTests" */;
+			buildPhases = (
+				2742F5E4104EC95466D713A3 /* Sources */,
+				9EDD6A0C2DAC6C9A9F1D629F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B29EEF4A8C112BF9FE1075F4 /* PBXTargetDependency */,
+			);
+			name = DemoAppTests;
+			packageProductDependencies = (
+				F7C3850B93A8BA0AF7FC42C9 /* AppScreenshotKit */,
+				624FD8E09263B91AAD38685C /* AppScreenshotKitTestTools */,
+			);
+			productName = DemoAppTests;
+			productReference = 593C65694F8FC82BA65DDC86 /* DemoAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CD9365CEE296087B81D5EDE0 /* DemoApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6BF92CDD7C5A429EE9438DB2 /* Build configuration list for PBXNativeTarget "DemoApp" */;
+			buildPhases = (
+				06C44C80621A0C39B6AB7A54 /* Sources */,
+				F3621958ACE022B3E174CC1E /* Resources */,
+				631EEB8FD7848E1438134A16 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DemoApp;
+			packageProductDependencies = (
+			);
+			productName = DemoApp;
+			productReference = 154FAE636D5E23DF886F3868 /* DemoApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3ACCC0531C14DF86AB1980F5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					98E24D6FA44C1D3D84659D04 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+					CD9365CEE296087B81D5EDE0 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = B9C4410D5AD85BE6945FC336 /* Build configuration list for PBXProject "DemoApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+				ja,
+			);
+			mainGroup = 440193E401A4E83EEA00B144;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				14D0028E5FFA9E10DDD93849 /* XCLocalSwiftPackageReference ".." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = D4CC74EBFCAF08A1E61D64BF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CD9365CEE296087B81D5EDE0 /* DemoApp */,
+				98E24D6FA44C1D3D84659D04 /* DemoAppTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F3621958ACE022B3E174CC1E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		06C44C80621A0C39B6AB7A54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7747C7646C100FF7FA2C55F9 /* DemoAppApp.swift in Sources */,
+				8C3488F436DA46D3B0F66587 /* MaterialDemoView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2742F5E4104EC95466D713A3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC5303E75A3E1D1BED05778B /* ScreenshotsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B29EEF4A8C112BF9FE1075F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CD9365CEE296087B81D5EDE0 /* DemoApp */;
+			targetProxy = 1D82B40CD4FBA248FDB68749 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		041C67ECF87CA2F42B2A6BA2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		17707D7259CA9368A4B03200 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		1C545C0DD7857285CD8FC0E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.appscreenshotkit.DemoApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		95986490CB804A49CF2F59B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.appscreenshotkit.DemoAppTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DemoApp";
+			};
+			name = Debug;
+		};
+		9F7979CEB628E6B55E2B4424 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.appscreenshotkit.DemoAppTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DemoApp";
+			};
+			name = Release;
+		};
+		AD50BDF0C399EC95218708BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.appscreenshotkit.DemoApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6BF92CDD7C5A429EE9438DB2 /* Build configuration list for PBXNativeTarget "DemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1C545C0DD7857285CD8FC0E0 /* Debug */,
+				AD50BDF0C399EC95218708BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B9C4410D5AD85BE6945FC336 /* Build configuration list for PBXProject "DemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17707D7259CA9368A4B03200 /* Debug */,
+				041C67ECF87CA2F42B2A6BA2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F9A1D6DC5F0C8CC9CE81F4D0 /* Build configuration list for PBXNativeTarget "DemoAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95986490CB804A49CF2F59B4 /* Debug */,
+				9F7979CEB628E6B55E2B4424 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		14D0028E5FFA9E10DDD93849 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		624FD8E09263B91AAD38685C /* AppScreenshotKitTestTools */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AppScreenshotKitTestTools;
+		};
+		F7C3850B93A8BA0AF7FC42C9 /* AppScreenshotKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AppScreenshotKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 3ACCC0531C14DF86AB1980F5 /* Project object */;
+}

--- a/Demo/DemoApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Demo/DemoApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demo/DemoApp/DemoAppApp.swift
+++ b/Demo/DemoApp/DemoAppApp.swift
@@ -1,0 +1,15 @@
+//
+//  DemoAppApp.swift
+//  DemoApp
+//
+
+import SwiftUI
+
+@main
+struct DemoAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MaterialDemoView()
+        }
+    }
+}

--- a/Demo/DemoApp/Info.plist
+++ b/Demo/DemoApp/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ja</string>
+	</array>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/Demo/DemoApp/MaterialDemoView.swift
+++ b/Demo/DemoApp/MaterialDemoView.swift
@@ -1,0 +1,74 @@
+//
+//  MaterialDemoView.swift
+//  DemoApp
+//
+
+import SwiftUI
+
+struct MaterialDemoView: View {
+    private let materials: [(String, Material)] = [
+        (".ultraThinMaterial", .ultraThinMaterial),
+        (".thinMaterial", .thinMaterial),
+        (".regularMaterial", .regularMaterial),
+        (".thickMaterial", .thickMaterial),
+    ]
+
+    var body: some View {
+        ZStack {
+            MaterialDemoBackground()
+
+            VStack(spacing: 80) {
+                ForEach(materials, id: \.0) { title, material in
+                    Text(title)
+                        .materialCard(material)
+                }
+            }
+            .padding(.top, 80)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+private struct MaterialDemoBackground: View {
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                LinearGradient(
+                    colors: [.red, .orange, .yellow, .green, .blue, .purple],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                VStack(spacing: 0) {
+                    ForEach(0..<48, id: \.self) { index in
+                        Rectangle()
+                            .fill(index.isMultiple(of: 2) ? Color.black.opacity(0.35) : .clear)
+                            .frame(height: proxy.size.height / 48)
+                    }
+                }
+
+                HStack(spacing: 0) {
+                    ForEach(0..<16, id: \.self) { index in
+                        Rectangle()
+                            .fill(index.isMultiple(of: 2) ? Color.white.opacity(0.22) : .clear)
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    fileprivate func materialCard(_ material: Material) -> some View {
+        self
+            .font(.system(size: 68, weight: .bold, design: .rounded))
+            .foregroundStyle(.black.opacity(0.75))
+            .frame(width: 980)
+            .padding(.vertical, 52)
+            .background(material, in: RoundedRectangle(cornerRadius: 44))
+            .overlay {
+                RoundedRectangle(cornerRadius: 44)
+                    .stroke(.white.opacity(0.55), lineWidth: 3)
+            }
+    }
+}

--- a/Demo/DemoAppTests/ScreenshotsTests.swift
+++ b/Demo/DemoAppTests/ScreenshotsTests.swift
@@ -1,0 +1,36 @@
+//
+//  ScreenshotsTests.swift
+//  DemoAppTests
+//
+//  Verifies Material rendering through a hosted UIApplication.
+//
+
+import AppScreenshotKit
+import AppScreenshotKitTestTools
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import DemoApp
+
+@AppScreenshot(.iPhone69Inch())
+struct MaterialDemo: View {
+    var body: some View {
+        MaterialDemoView()
+    }
+}
+
+@MainActor
+@Test func exportMaterialScreenshot() throws {
+    let exporter = AppScreenshotExporter(
+        option: .file(
+            outputURL: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("AppScreenshotKitMaterialDemo"),
+            imageFormat: .jpeg(compressionQuality: 0.6)
+        )
+    )
+
+    let outputs = try exporter.export(MaterialDemo.self)
+    #expect(outputs.count == 1)
+    #expect(!outputs[0].imageData.isEmpty)
+}

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ Before using Apple’s marketing resources, review the [App Store marketing guid
 
 Run `DemoTests` in Xcode to generate sample outputs under `Demo/Screenshots`.
 
+SwiftUI Materials (`.thinMaterial`, `.ultraThinMaterial`, etc.) are backed by
+`UIVisualEffectView` and require a hosted `UIApplication` to render in exported
+screenshots. `Demo/DemoApp.xcodeproj` contains a minimal host-app test target
+for that path.
+
 ## Requirements
 
 - iOS 16+ / macOS 14+

--- a/Sources/AppScreenshotCore/Utils/PNGDataConverter.swift
+++ b/Sources/AppScreenshotCore/Utils/PNGDataConverter.swift
@@ -17,6 +17,15 @@ struct PNGDataConverter {
         imageFormat: AppScreenshotImageFormat = .png
     ) throws -> Data {
         #if canImport(UIKit)
+            if let data = try renderInHostApp(
+                content: content,
+                rect: rect,
+                scale: scale,
+                imageFormat: imageFormat
+            ) {
+                return data
+            }
+
             let controller = UIHostingController(rootView: content)
             if #available(iOS 16.4, *) {
                 controller.safeAreaRegions = []
@@ -87,3 +96,94 @@ struct PNGDataConverter {
         #endif
     }
 }
+
+#if canImport(UIKit)
+    extension PNGDataConverter {
+        fileprivate func renderInHostApp<Content: View>(
+            content: Content,
+            rect: CGRect?,
+            scale: CGFloat,
+            imageFormat: AppScreenshotImageFormat
+        ) throws -> Data? {
+            guard
+                let scene = UIApplication.shared.connectedScenes
+                    .compactMap({ $0 as? UIWindowScene })
+                    .first(where: { !$0.windows.isEmpty }),
+                let keyWindow = scene.windows.first(where: \.isKeyWindow)
+                    ?? scene.windows.first
+            else { return nil }
+
+            let nativeScale = scene.screen.scale
+            let screenPointSize = scene.screen.bounds.size
+
+            let controller = UIHostingController(rootView: content)
+            if #available(iOS 16.4, *) {
+                controller.safeAreaRegions = []
+            }
+            controller.view.backgroundColor = .clear
+
+            let pixelSize = controller.view.intrinsicContentSize
+            let pointSize = CGSize(
+                width: pixelSize.width / nativeScale,
+                height: pixelSize.height / nativeScale
+            )
+
+            // drawHierarchy clips outside the window; let the existing fallback
+            // handle oversized compositions.
+            guard
+                pointSize.width <= screenPointSize.width,
+                pointSize.height <= screenPointSize.height
+            else { return nil }
+
+            let originalRoot = keyWindow.rootViewController
+            keyWindow.rootViewController = controller
+            defer { keyWindow.rootViewController = originalRoot }
+
+            controller.view.bounds = CGRect(origin: .zero, size: pixelSize)
+            controller.view.transform = CGAffineTransform(
+                scaleX: 1 / nativeScale,
+                y: 1 / nativeScale
+            )
+            controller.view.center = CGPoint(
+                x: pointSize.width / 2,
+                y: pointSize.height / 2
+            )
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+
+            let cropPixelRect = rect ?? CGRect(origin: .zero, size: pixelSize)
+            let cropPointRect = CGRect(
+                x: cropPixelRect.origin.x / nativeScale,
+                y: cropPixelRect.origin.y / nativeScale,
+                width: cropPixelRect.size.width / nativeScale,
+                height: cropPixelRect.size.height / nativeScale
+            )
+
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = nativeScale * scale
+            format.opaque = false
+
+            let renderer = UIGraphicsImageRenderer(size: cropPointRect.size, format: format)
+            let render: (UIGraphicsImageRendererContext) -> Void = { ctx in
+                ctx.cgContext.translateBy(
+                    x: -cropPointRect.origin.x,
+                    y: -cropPointRect.origin.y
+                )
+                controller.view.drawHierarchy(
+                    in: controller.view.frame,
+                    afterScreenUpdates: true
+                )
+            }
+
+            switch imageFormat {
+            case .png:
+                return renderer.pngData(actions: render)
+            case .jpeg:
+                return renderer.jpegData(
+                    withCompressionQuality: imageFormat.clampedCompressionQuality,
+                    actions: render
+                )
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- render UIKit exports through an available host app window first so UIVisualEffectView-backed SwiftUI Materials are captured
- keep the existing detached-window renderer as a fallback for SPM-only and oversized exports
- add a minimal DemoApp host-app test target with a Material demo view

## Validation
- swift format lint Demo/DemoApp/MaterialDemoView.swift Demo/DemoAppTests/ScreenshotsTests.swift Sources/AppScreenshotCore/Utils/PNGDataConverter.swift --configuration .swift-format
- swift test
- xcodebuild test -project Demo/DemoApp.xcodeproj -scheme DemoApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'

Closes #20